### PR TITLE
Users: Fix create user URL

### DIFF
--- a/src/components/SignUpForm.tsx
+++ b/src/components/SignUpForm.tsx
@@ -17,7 +17,7 @@ const SignUpForm: React.FC = () => {
     try {
       const token = localStorage.getItem('token')
       const response = await axios.post(
-        `${URL}/user`,
+        `${URL}/users`,
         {
           email,
           password,


### PR DESCRIPTION
Creating a new user I got the 404 error. I noticed the url was out-dated

<img width="707" alt="image" src="https://github.com/mimic-fi/v3-backend-app/assets/12477284/62cf1667-24bf-4bef-b699-0af12583b6e6">
