### PR TITLE
Fix: Update format formula

### DIFF
--- a/src/utils/math-utils.js
+++ b/src/utils/math-utils.js
@@ -51,7 +51,7 @@ export function formatTokenAmount(
     amountDecimal = amountDecimal.neg();
   }
 
-  let divisor = Decimal.pow(10, decimalsDecimal.minus(digits));
+  let divisor = Decimal.pow(10, decimalsDecimal);
   let amountConverted = decimalsDecimal.equals(0) ? amountDecimal : amountDecimal.div(divisor).toFixed(digits.toNumber(), Decimal.ROUND_HALF_UP);
   let amountConvertedStr = String(amountConverted);
 


### PR DESCRIPTION
I was checking the balance of the wallets and I've noticed that the amounts were off by some decimals. Reviewing the formula I think I found the bug. Take a look at the amounts in the captures below

## Before:
<img width="458" alt="Screenshot 2024-03-07 at 11 07 28" src="https://github.com/mimic-fi/v3-backend-app/assets/12477284/6c8aca50-0e20-4d73-b718-337a5c18235e">
<img width="961" alt="Screenshot 2024-03-07 at 11 05 10" src="https://github.com/mimic-fi/v3-backend-app/assets/12477284/7c83a504-9b61-4b5a-9328-ef79d6c9bbf1">
<img width="1571" alt="Screenshot 2024-03-07 at 11 06 13" src="https://github.com/mimic-fi/v3-backend-app/assets/12477284/aa4a63b6-16fa-4103-9559-c608bdb04209">

## After
<img width="421" alt="Screenshot 2024-03-07 at 11 04 16" src="https://github.com/mimic-fi/v3-backend-app/assets/12477284/d0ff54da-6b70-4a40-8736-318b551b34e9">
<img width="962" alt="Screenshot 2024-03-07 at 11 05 58" src="https://github.com/mimic-fi/v3-backend-app/assets/12477284/8654b3f4-4f8b-4858-8f74-1a13e51b6770">
<img width="1567" alt="Screenshot 2024-03-07 at 11 06 19" src="https://github.com/mimic-fi/v3-backend-app/assets/12477284/1c5c695c-b94d-4b8b-b325-9f256eb0184a">
